### PR TITLE
Replace twitter.com or x.com with vxtwitter.com

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -18,6 +18,35 @@ async def on_ready():
     print(f"Bot is online")
     await bot.change_presence(activity=discord.Activity(type=discord.ActivityType.watching, name="for pixiv links"))
 
+
+
+@bot.event
+async def on_message(message):
+    if message.author == bot.user:
+        return
+
+    if ("twitter.com/" in message.content or "x.com/" in message.content) and not message.content.startswith("twitter.com") and not message.content.startswith("x.com"):
+        # Message contains Twitter or x.com URLs, and it is not a direct link
+        urls = message.content.split()
+        modified_urls = []
+
+        for url in urls:
+            if "twitter.com" in url or "x.com" in url:
+                # Replace twitter.com or x.com with vxtwitter.com
+                modified_url = url.replace("twitter.com", "vxtwitter.com").replace("x.com", "vxtwitter.com")
+                modified_urls.append(modified_url)
+            else:
+                modified_urls.append(url)
+
+        modified_content = ' '.join(modified_urls)
+
+        # Send the modified message as a reply without mentioning the user
+        await message.reply(modified_content, allowed_mentions=discord.AllowedMentions.none())
+
+    # Continue with other message processing
+    await bot.process_commands(message)
+
+
 try:
     bot.run(os.environ.get("TOKEN"))
 except Exception as err:


### PR DESCRIPTION
It's a very simple feature and simple code

Twitter,x has changed the robot.txt so that Discord can no longer access it and the 
which means we can no longer see the embed message 

I don't think it's appropriate for such a simple feature to go into new bot or add another bot, as these features are very similar to the existing piciv features. 
I thought it was appropriate and added the functionality 
Please review if you don't mind
![image](https://github.com/VoltIcaRus/picsiv/assets/3735740/8ffbde7f-5961-4fb3-a094-74e99bba3d69)
